### PR TITLE
change poll answering to happen all at once

### DIFF
--- a/backend/src/controllers/pollController.ts
+++ b/backend/src/controllers/pollController.ts
@@ -59,9 +59,11 @@ const callService = async (
         // Bad request
         if (e instanceof AssertionError) {
             Logger.warn(`Bad Request: ${e.message}`);
+            Logger.warn(e.stack);
             return responses.badRequest(req, res);
         } else if (e instanceof BadRequestError) {
             Logger.warn(`Bad Request: ${e.message}`);
+            Logger.warn(e.stack);
             return responses.badRequest(req, res);
         }
 

--- a/backend/src/models/BooleanQuestion.test.ts
+++ b/backend/src/models/BooleanQuestion.test.ts
@@ -3,7 +3,7 @@ import BooleanQuestion from './BooleanQuestion';
 
 describe('BooleanQuestion', () => {
     describe('answerDataIsAcceptable', () => {
-        test('Answer data with boolean answer is accepted', () => {
+        test('Answer data with true answer is accepted', () => {
             const question = new BooleanQuestion(prismaMock);
 
             expect(
@@ -11,12 +11,16 @@ describe('BooleanQuestion', () => {
                     answer: true
                 })
             ).toBe(true);
+        });
+
+        test('Answer data with false answer is not accepted', () => {
+            const question = new BooleanQuestion(prismaMock);
 
             expect(
                 question.answerDataIsAcceptable({
                     answer: false
                 })
-            ).toBe(true);
+            ).toBe(false);
         });
 
         test('Answer data with non-boolean answer is not accepted', () => {

--- a/backend/src/models/BooleanQuestion.ts
+++ b/backend/src/models/BooleanQuestion.ts
@@ -50,14 +50,14 @@ export default class BooleanQuestion extends Question {
 
     /**
      * Whether given answer data object is acceptable to the question.
-     * The answer property of the object must be a boolean to be accepted.
+     * The answer property of the object must be true in order to be accepted.
+     * BooleanQuestions are never answered with false. The lack
+     * of an answer is taken to mean the question was
+     * answered false.
      */
 
     answerDataIsAcceptable(answerData: AnswerData): boolean {
-        return (
-            typeof answerData === 'object' &&
-            typeof answerData.answer === 'boolean'
-        );
+        return typeof answerData === 'object' && answerData.answer === true;
     }
 
     /**

--- a/backend/src/models/IQuestion.ts
+++ b/backend/src/models/IQuestion.ts
@@ -5,6 +5,11 @@ export interface AnswerData {
     [extra: string]: unknown;
 }
 
+export interface Answer {
+    questionId: string;
+    data: AnswerData;
+}
+
 export interface NewOptionData {
     option: string;
     questionId: string;

--- a/backend/src/models/NumberQuestion.ts
+++ b/backend/src/models/NumberQuestion.ts
@@ -16,10 +16,8 @@ export default class NumberQuestion extends Question {
 
     /**
      * A discrete step the given number must consist of.
-     * For example, step = 1 would mean only whole integers
-     * are allowed. Or if step = 0.01 then only values such as
-     * -0.01, 0.01, 0.02, etc. are allowed. Note: The step
-     * value can have at most 6 decimal places of precision.
+     * Or in other words, any valid value must be divisible
+     * by step. Step must be an integer.
      * Step = -1 means no step value is set.
      */
 
@@ -63,7 +61,7 @@ export default class NumberQuestion extends Question {
 
     isValidValue(num: number): boolean {
         if (this.isDiscrete()) {
-            return this._round(num) % this._round(this.step()) === 0;
+            return num % this.step() === 0;
         } else {
             return true;
         }

--- a/backend/src/models/Poll.test.ts
+++ b/backend/src/models/Poll.test.ts
@@ -46,10 +46,14 @@ describe('Poll', () => {
             const user = makeAnswerer();
 
             await poll.answer(
-                'question-id',
-                {
-                    answer: 'answer'
-                },
+                [
+                    {
+                        questionId: 'question-id',
+                        data: {
+                            answer: 'answer'
+                        }
+                    }
+                ],
                 user
             );
 

--- a/backend/src/models/Poll.ts
+++ b/backend/src/models/Poll.ts
@@ -319,8 +319,21 @@ export default class Poll {
         question.setDatabase(this.database());
 
         await question.answer(answerData, user);
+    }
 
-        await this.incrementAnswerCount();
+    /**
+     *
+     */
+
+    async _answerMultipleWithRights(
+        answers: Array<IQuestion.Answer>,
+        user: User
+    ): Promise<void> {
+        for (let i = 0; i < answers.length; i++) {
+            const answer = answers[i];
+
+            await this._answerWithRights(answer.questionId, answer.data, user);
+        }
     }
 
     /**
@@ -377,6 +390,97 @@ export default class Poll {
         question.setFromDatabaseData(questionData);
 
         this.questions()[question.id()] = question;
+    }
+
+    /**
+     * Whether given answer has corresponding question in
+     * poll. If so, alreadyMatched is updated accordingly.
+     * If alreadyMatched already contains the corresponding question id,
+     * returns false.
+     */
+
+    _answerMatchesQuestion(
+        alreadyMatched: { [questionId: string]: boolean },
+        answer: IQuestion.Answer
+    ): boolean {
+        if (
+            alreadyMatched[answer.questionId] !== true &&
+            this.questions()[answer.questionId] instanceof Question
+        ) {
+            alreadyMatched[answer.questionId] = true;
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Whether given answers match the questions of this poll.
+     * As in, whether for each of the answer there
+     * exists a question in the poll with the same id.
+     * Also demands that there are no duplicate answers for the
+     * same question.
+     */
+
+    _answersMatchQuestions(answers: Array<IQuestion.Answer>): boolean {
+        const alreadyMatched: { [questionId: string]: boolean } = {};
+
+        for (let i = 0; i < answers.length; i++) {
+            if (!this._answerMatchesQuestion(alreadyMatched, answers[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Whether poll's question accepts given answer data.
+     */
+
+    _questionAcceptsAnswer(
+        questionId: string,
+        data: IQuestion.AnswerData
+    ): boolean {
+        const question = this.questions()[questionId];
+
+        return question.answerDataIsAcceptable(data);
+    }
+
+    /**
+     * Whether all poll's questions accept the
+     * answer datas given.
+     */
+
+    _questionsAcceptAnswers(answers: Array<IQuestion.Answer>): boolean {
+        for (let i = 0; i < answers.length; i++) {
+            const answer = answers[i];
+
+            if (!this._questionAcceptsAnswer(answer.questionId, answer.data)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Whether given array of answer objects is a valid
+     * collection of answers for this poll. Only checks whether the question's
+     * match the poll's questions adequately, does not check answer validity
+     * for each question separately.
+     */
+
+    _answersIsValid(answers: Array<IQuestion.Answer>): boolean {
+        if (answers.length !== Object.keys(this.questions()).length) {
+            return false;
+        }
+
+        return (
+            this._answersMatchQuestions(answers) &&
+            this._questionsAcceptAnswers(answers)
+        );
     }
 
     constructor(database: PrismaClient, questionFactory: QuestionFactory) {
@@ -604,25 +708,17 @@ export default class Poll {
     }
 
     /**
-     * Gives an answer to a question in the poll from given user.
-     * Makes all needed modifications
-     * to database and returns Answer object representing
-     * the created answer.
-     * If given answer data is not of acceptable format for the question,
-     * does nothing and returns undefined.
+     * Answers all questions directly under the poll from given user.
+     * Makes all needed modifications to database.
+     * If answers is not acceptable to poll
+     * or the poll's questions, does nothing and throws BadRequestError.
      */
-    async answer(
-        questionId: string,
-        answerData: IQuestion.AnswerData,
-        user: User
-    ): Promise<void> {
-        pre(
-            'poll has question',
-            this.questions()[questionId] instanceof Question
-        );
+    async answer(answers: Array<IQuestion.Answer>, user: User): Promise<void> {
+        pre('given answers is valid', this._answersIsValid(answers));
 
         if (this.userHasRightToAnswerPoll(user)) {
-            await this._answerWithRights(questionId, answerData, user);
+            await this._answerMultipleWithRights(answers, user);
+            await this.incrementAnswerCount();
         } else {
             // Make this return 403! - Joonas Hiltunen 04.11.2022
             throw new Error(

--- a/backend/src/models/Question.ts
+++ b/backend/src/models/Question.ts
@@ -319,9 +319,8 @@ export default class Question {
     ): void {
         let answerCount = this.answerCount();
         for (let i = 0; i < answersData.length; i++) {
-            answerCount += this._setAnswerFromDatabaseData(
-                answersData[i]
-            ).count();
+            this._setAnswerFromDatabaseData(answersData[i]);
+            answerCount += 1;
         }
         this._setOwnAnswerCounts(answerCount);
     }

--- a/backend/src/routes/v1/swagger_api_v1.json
+++ b/backend/src/routes/v1/swagger_api_v1.json
@@ -137,7 +137,7 @@
             },
             "post": {
                 "tags": ["Poll public"],
-                "description": "Answers a sub-question of a poll's question. The questionId should be the id of the question to answer. The question type should be specified. Different question types are: \"free\" (free-form text question), \"multi\" (question containing sub-questions), \"number\" (number question), \"scale\" (number question with a specified range of allowed values).\n",
+                "description": "Answers all the poll's questions at once. All questions directly under the poll are mandatory and need to be answered. On the other hand, a sub-question of a multi-question follows the restrictions of the multi-question and thus may contain optional questions.",
                 "parameters": [
                     {
                         "in": "path",
@@ -171,9 +171,42 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/AddAnswer"
+                                "$ref": "#/components/schemas/PollAnswerRequest"
                             }
                         }
+                    }
+                }
+            }
+        },
+        "/api/poll/{publicId}/results": {
+            "get": {
+                "tags": ["Poll public"],
+                "description": "Returns answer result statistics about the poll. For each question result, .answerPercentage tells the ratio of the question's .answerCount to its parent's .answerCount. The parent of a sub-question is the multi-question containing it. On the other hand, the parent of a non-sub-question is the poll itself. .answerValueStatistics contains information about the answer counts for different answer values under a question. The .percentage of these statistic objects is the ratio of the statistic object's .count to the question's .answerCount.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "publicId",
+                        "description": "publicId of the poll to get results of.",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Information about the poll's answer results.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PollResults"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Poll not found"
                     }
                 }
             }
@@ -268,7 +301,8 @@
         "schemas": {
             "QuestionType": {
                 "type": "string",
-                "description": "One of: \"free\" (free-form text question), \"multi\" (question containing sub-questions), \"number\" (number question), \"scale\" (number question with a specified range of allowed values)."
+                "description": "One of: \"free\" (free-form text question), \"multi\" (question containing sub-questions), \"number\" (number question), \"scale\" (number question with a specified range of allowed values).",
+                "example": "free"
             },
             "AddPoll": {
                 "properties": {
@@ -424,6 +458,35 @@
                     }
                 }
             },
+            "PollResults": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Name of the poll"
+                    },
+                    "publicId": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "questions": {
+                        "type": "array",
+                        "items": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/components/schemas/MultiQuestionResult"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/QuestionResult"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
             "AddAnswer": {
                 "properties": {
                     "questionId": {
@@ -431,27 +494,55 @@
                         "format": "uuid"
                     },
                     "type": {
-                        "$ref": "#/components/schemas/QuestionType"
+                        "type": "string",
+                        "example": "multi"
                     },
                     "answer": {
                         "oneOf": [
                             {
                                 "type": "object",
                                 "properties": {
-                                    "subQuestionId": {
-                                        "type": "string",
-                                        "format": "uuid"
+                                    "subQuestionIds": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "format": "uuid"
+                                        }
                                     },
                                     "answer": {
-                                        "type": "string"
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "answer": {
+                                                    "type": "string",
+                                                    "example": "test-text-value"
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             },
                             {
-                                "type": "string",
-                                "example": "test-text-value"
+                                "type": "object",
+                                "properties": {
+                                    "answer": {
+                                        "type": "string",
+                                        "example": "test-text-value"
+                                    }
+                                }
                             }
                         ]
+                    }
+                }
+            },
+            "PollAnswerRequest": {
+                "properties": {
+                    "answers": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AddAnswer"
+                        }
                     }
                 }
             },
@@ -535,6 +626,97 @@
                         "example": 5
                     },
                     "step": {
+                        "type": "number",
+                        "example": 1
+                    }
+                }
+            },
+            "QuestionResult": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "title": {
+                        "type": "string",
+                        "example": "Title of the sub-question"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "Description of the sub-question"
+                    },
+                    "pollId": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/QuestionType"
+                    },
+                    "answerCount": {
+                        "type": "number",
+                        "example": 1
+                    },
+                    "answerPercentage": {
+                        "type": "number",
+                        "example": 1
+                    },
+                    "answerValueStatistics": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AnswerValueStatistic"
+                        }
+                    }
+                }
+            },
+            "MultiQuestionResult": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "title": {
+                        "type": "string",
+                        "example": "Title of the sub-question"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "Description of the sub-question"
+                    },
+                    "pollId": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "type": {
+                        "type": "string",
+                        "example": "multi"
+                    },
+                    "answerCount": {
+                        "type": "number",
+                        "example": 1
+                    },
+                    "answerPercentage": {
+                        "type": "number",
+                        "example": 1
+                    },
+                    "subQuestions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/QuestionResult"
+                        }
+                    }
+                }
+            },
+            "AnswerValueStatistic": {
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "example": "true"
+                    },
+                    "count": {
+                        "type": "number",
+                        "example": 1
+                    },
+                    "percentage": {
                         "type": "number",
                         "example": 1
                     }

--- a/backend/src/services/IVotingService.ts
+++ b/backend/src/services/IVotingService.ts
@@ -1,10 +1,8 @@
+import * as IQuestion from '../models/IQuestion';
+
 export interface AnswerData {
     publicId: string;
-    questionId: string;
-    answer: {
-        answer: number | string | object | boolean;
-        [extra: string]: unknown;
-    };
+    answers: Array<IQuestion.Answer>;
     answerer: {
         ip: string;
         cookie: string;

--- a/backend/src/services/VotingService.test.ts
+++ b/backend/src/services/VotingService.test.ts
@@ -136,15 +136,23 @@ describe('VotingService', () => {
                 new QuestionFactory(prismaMock)
             );
 
+            const answersData = [
+                {
+                    questionId: 'q1',
+                    data: {
+                        answer: {
+                            subQuestionId: 'o1',
+                            answer: {
+                                answer: true
+                            }
+                        }
+                    }
+                }
+            ];
+
             await service.answerPoll({
                 publicId: '1',
-                questionId: 'q1',
-                answer: {
-                    subQuestionId: 'o1',
-                    answer: {
-                        answer: true
-                    }
-                },
+                answers: answersData,
                 answerer: {
                     ip: '1',
                     cookie: '2',
@@ -154,13 +162,7 @@ describe('VotingService', () => {
 
             expect(Poll.prototype.answer).toHaveBeenCalledTimes(1);
             expect(Poll.prototype.answer).toHaveBeenCalledWith(
-                'q1',
-                {
-                    subQuestionId: 'o1',
-                    answer: {
-                        answer: true
-                    }
-                },
+                answersData,
                 createMockUser()
             );
         });
@@ -174,10 +176,14 @@ describe('VotingService', () => {
             try {
                 await service.answerPoll({
                     publicId: '1',
-                    questionId: 'q1',
-                    answer: {
-                        answer: true
-                    },
+                    answers: [
+                        {
+                            questionId: 'q1',
+                            data: {
+                                answer: true
+                            }
+                        }
+                    ],
                     answerer: {
                         ip: '1',
                         cookie: '2',

--- a/backend/src/services/VotingService.ts
+++ b/backend/src/services/VotingService.ts
@@ -110,11 +110,7 @@ export default class VotingService {
         answerData: IVotingService.AnswerData,
         user: User
     ): Promise<void> {
-        await poll.answer(
-            answerData.questionId,
-            answerData.answer,
-            user as User
-        );
+        await poll.answer(answerData.answers, user as User);
     }
 
     constructor(database: PrismaClient, questionFactory: QuestionFactory) {
@@ -285,8 +281,8 @@ export default class VotingService {
         );
 
         pre(
-            'answerData.answer is of type object',
-            typeof answerData.answer === 'object'
+            'answerData.answers is of type Array',
+            Array.isArray(answerData.answers)
         );
 
         const user = await this._tryGettingUser(answerData.answerer);


### PR DESCRIPTION
### Fixes #110

## Describe your changes

Changed poll answering so that all of the poll's questions are answered in one request. Before the poll's questions needed to be answered one at a time which was inefficient and made it too difficult to track how many times the poll has been answered. No new unit tests added. The integration test poll.test.ts was updated for the new api. Documentation was also updated for poll answering. Also added the missing documentation for poll results.

Note: this update will break the current frontend integration for poll answering.

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added thorough tests
