### PR TITLE
Route poll creator to result page with unique poll id

### DIFF
--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -76,6 +76,15 @@ function App() {
                                     />
                                 }
                             />
+                            <Route
+                                path={'/result/' + pollId}
+                                element={
+                                    <PollResult
+                                        pollId={pollId}
+                                        showNotification={handleNotification}
+                                    />
+                                }
+                            />
                         </Routes>
                         <BasicSnackbar
                             open={open}

--- a/frontend/src/components/PollCreation.tsx
+++ b/frontend/src/components/PollCreation.tsx
@@ -11,8 +11,11 @@ import './PollCreation.scss';
 import Question from './Question';
 import { createPoll } from '../services/pollService';
 import { PollQuesObj } from '../utils/types';
+import { useNavigate } from 'react-router-dom';
 
 function PollCreation(props: any) {
+    const navigate = useNavigate();
+
     const [showQuesContainer, setShowQuesContainer] = useState(false);
     const [questions, setQuestions] = useState<PollQuesObj[]>([
         {
@@ -192,7 +195,7 @@ function PollCreation(props: any) {
     const submitHandler = () => {
         console.log(questions, pollName, showCount);
 
-        createPoll(pollName, questions)
+        createPoll(pollName, questions, [])
             .then((response) => {
                 console.log(response.publicId);
                 // 1576d894-2571-4281-933d-431d246bb460
@@ -201,6 +204,7 @@ function PollCreation(props: any) {
                     severity: 'success',
                     message: 'Poll Created successfully'
                 });
+                navigate(`result/${response.publicId}`);
             })
             .catch((error) => {
                 console.log(error);

--- a/frontend/src/components/__tests__/PollCreation.test.tsx
+++ b/frontend/src/components/__tests__/PollCreation.test.tsx
@@ -1,28 +1,51 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter as Router } from 'react-router-dom';
 import PollCreation from '../PollCreation';
 // import UserEvent from '@testing-library/user-event';
 
+const mockedUsedNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedUsedNavigate
+}));
+
 test('Renders page heading', () => {
-    render(<PollCreation />);
+    render(
+        <Router>
+            <PollCreation />
+        </Router>
+    );
     const pageTitle = screen.getByText('Create poll');
     expect(pageTitle).toBeInTheDocument();
 });
 
 test('Renders submit button for submitting the poll questions', () => {
-    render(<PollCreation />);
+    render(
+        <Router>
+            <PollCreation />
+        </Router>
+    );
     const button = screen.getByRole('button', { name: 'Submit Poll' });
     expect(button).toBeInTheDocument();
     expect(button.getAttribute('type')).toBe('submit');
 });
 
 test('Renders button for adding a poll question', () => {
-    render(<PollCreation />);
+    render(
+        <Router>
+            <PollCreation />
+        </Router>
+    );
     const button = screen.getByRole('button', { name: 'Add a question' });
     expect(button).toBeInTheDocument();
 });
 
 test('Page includes text input for poll name', () => {
-    render(<PollCreation />);
+    render(
+        <Router>
+            <PollCreation />
+        </Router>
+    );
     const field = screen.getByTestId('poll-name-field');
     expect(field).toBeInTheDocument();
 

--- a/frontend/src/services/pollService.ts
+++ b/frontend/src/services/pollService.ts
@@ -57,7 +57,11 @@ const updatePollBody = (questions: PollQuesObj[]) => {
  * @param questions
  * @returns
  */
-export const createPoll = async (title: string, questions: any) => {
+export const createPoll = async (
+    title: string,
+    questions: any,
+    visualFlags: any
+) => {
     const updatedQuestions = updatePollBody(questions);
     const pollContent = {
         name: title,
@@ -65,7 +69,8 @@ export const createPoll = async (title: string, questions: any) => {
         owner: {
             accountId: '3fa85f64-5717-4562-b3fc-2c963f66afa6' // hardcoded
         },
-        questions: updatedQuestions
+        questions: updatedQuestions,
+        visualFlags: visualFlags
     };
     console.log(pollContent);
     const response = await fetch(`${getBackendUrl()}/api/poll`, {


### PR DESCRIPTION
### Fixes #135 

## Describe your changes

After creating poll, the user is redirected to the result page: `path={'/result/' + pollId}`
`pollId` is unique for the poll, and that can be used when answering the poll as well.

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added thorough tests
