### PR TITLE
Organize routes better

### DIFF
--- a/backend/src/middlewares/authenticationHandler.test.ts
+++ b/backend/src/middlewares/authenticationHandler.test.ts
@@ -95,7 +95,7 @@ describe('authenticationHandler', () => {
             };
         });
 
-        test('Should return forbidden if user not set', async () => {
+        test('Should return unauthorized if user not set', async () => {
             mockRequest.User = undefined;
 
             await authenticationHandler.requireUser()(
@@ -104,7 +104,7 @@ describe('authenticationHandler', () => {
                 mockNext
             );
 
-            expect(mockedResponses.forbidden).toBeCalledTimes(1);
+            expect(mockedResponses.unauthorized).toBeCalledTimes(1);
             expect(mockRequest.User).toBeUndefined();
             expect(mockRequest.UserIsAdmin).toBeUndefined();
         });
@@ -148,7 +148,7 @@ describe('authenticationHandler', () => {
             };
         });
 
-        test('Should return forbidden if user not set', async () => {
+        test('Should return unauthorized if user not set', async () => {
             mockRequest.User = undefined;
 
             await authenticationHandler.requireAdmin()(
@@ -157,12 +157,12 @@ describe('authenticationHandler', () => {
                 mockNext
             );
 
-            expect(mockedResponses.forbidden).toBeCalledTimes(1);
+            expect(mockedResponses.unauthorized).toBeCalledTimes(1);
             expect(mockRequest.User).toBeUndefined();
             expect(mockRequest.UserIsAdmin).toBeUndefined();
         });
 
-        test('Should return unauthorized if user is not admin', async () => {
+        test('Should return forbidden if user is not admin', async () => {
             mockedIsAdmin.mockResolvedValueOnce(false);
 
             await authenticationHandler.requireAdmin()(
@@ -171,7 +171,7 @@ describe('authenticationHandler', () => {
                 mockNext
             );
 
-            expect(mockedResponses.unauthorized).toBeCalledTimes(1);
+            expect(mockedResponses.forbidden).toBeCalledTimes(1);
             expect(mockRequest.User).toEqual(data);
             expect(mockRequest.UserIsAdmin).toEqual(false);
         });

--- a/backend/src/middlewares/authenticationHandler.ts
+++ b/backend/src/middlewares/authenticationHandler.ts
@@ -49,7 +49,7 @@ export const requireUser = () => {
             const user = req.User;
 
             if (!user) {
-                return responses.forbidden(req, res);
+                return responses.unauthorized(req, res);
             }
 
             req.UserIsAdmin = await isAdmin(user.userName, prisma);
@@ -78,14 +78,14 @@ export const requireAdmin = () => {
             const user = req.User;
 
             if (!user) {
-                return responses.forbidden(req, res);
+                return responses.unauthorized(req, res);
             }
 
             const userIsAdmin = await isAdmin(user.userName, prisma);
             req.UserIsAdmin = userIsAdmin;
 
             if (!userIsAdmin) {
-                return responses.unauthorized(req, res);
+                return responses.forbidden(req, res);
             }
 
             return next();

--- a/backend/src/routes/v1/poll.ts
+++ b/backend/src/routes/v1/poll.ts
@@ -1,69 +1,10 @@
 import { Router } from 'express';
-import {
-    requireAdmin,
-    requireUser,
-    authenticate
-} from '../../middlewares/authenticationHandler';
-import {
-    createPoll,
-    answerPoll,
-    getPublicPoll,
-    getPrivatePoll,
-    getPollAnswers,
-    getPollResults,
-    editPoll,
-    deletePoll,
-    searchByName
-} from '../../controllers/pollController';
+
+import { requireAdmin } from '../../middlewares/authenticationHandler';
+import { router as pollAdminRouter } from './poll/admin';
+import { router as pollPublicRouter } from './poll/public';
 
 export const router = Router();
 
-/**
- * Create poll
- */
-router.post('/', createPoll);
-
-/**
- * Get answers of a poll
- */
-router.get('/:publicId/answers', getPollAnswers);
-
-/**
- * Get results of a poll
- */
-router.get('/:publicId/results', getPollResults);
-
-/**
- * Answer poll
- */
-router.post('/:publicId/answers', answerPoll);
-
-/**
- * Gets polls public information
- */
-router.get('/:publicId', getPublicPoll);
-
-/**
- * Gets polls info for admin view
- */
-router.get('/admin/:privateId', authenticate(), requireAdmin(), getPrivatePoll);
-
-/**
- * Gets private info of polls as admin using poll name search string
- */
-router.get(
-    '/admin/searchByName/:searchString',
-    authenticate(),
-    requireAdmin(),
-    searchByName
-);
-
-/**
- * Deletes poll as admin
- */
-router.delete('/admin/:privateId', authenticate(), requireAdmin(), deletePoll);
-
-/**
- * Edits poll as admin
- */
-router.patch('/admin/:privateId', authenticate(), requireAdmin(), editPoll);
+router.use('/', pollPublicRouter);
+router.use('/admin', requireAdmin(), pollAdminRouter);

--- a/backend/src/routes/v1/poll/admin.ts
+++ b/backend/src/routes/v1/poll/admin.ts
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+
+import {
+    deletePoll,
+    editPoll,
+    getPrivatePoll,
+    searchByName
+} from '../../../controllers/pollController';
+
+export const router = Router();
+
+// All endpoints placed in this file require admin account
+
+/**
+ * Gets polls info for admin view
+ */
+router.get('/:privateId', getPrivatePoll);
+
+/**
+ * Gets private info of polls as admin using poll name search string
+ */
+router.get('/searchByName/:searchString', searchByName);
+
+/**
+ * Deletes poll as admin
+ */
+router.delete('/:privateId', deletePoll);
+
+/**
+ * Edits poll as admin
+ */
+router.patch('/:privateId', editPoll);

--- a/backend/src/routes/v1/poll/public.ts
+++ b/backend/src/routes/v1/poll/public.ts
@@ -1,0 +1,36 @@
+import { Router } from 'express';
+
+import {
+    answerPoll,
+    createPoll,
+    getPollAnswers,
+    getPollResults,
+    getPublicPoll
+} from '../../../controllers/pollController';
+
+export const router = Router();
+
+/**
+ * Create poll
+ */
+router.post('/', createPoll);
+
+/**
+ * Gets polls public information
+ */
+router.get('/:publicId', getPublicPoll);
+
+/**
+ * Get answers of a poll
+ */
+router.get('/:publicId/answers', getPollAnswers);
+
+/**
+ * Get results of a poll
+ */
+router.get('/:publicId/results', getPollResults);
+
+/**
+ * Answer poll
+ */
+router.post('/:publicId/answers', answerPoll);

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -8,5 +8,6 @@
         "strict": true,
         "resolveJsonModule": true
     },
+    "include": ["./src/**/*.ts"],
     "files": ["./src/types/express/index.d.ts"]
 }

--- a/backend/tsconfig.production.json
+++ b/backend/tsconfig.production.json
@@ -9,6 +9,7 @@
         "resolveJsonModule": true,
         "removeComments": true
     },
+    "include": ["./src/**/*.ts"],
     "exclude": ["**/*.test.ts", "**/prisma_singleton.ts"],
     "files": ["./src/types/express/index.d.ts"]
 }


### PR DESCRIPTION
## Describe your changes

- Organized the routes for the poll to two separate files, one for admin and one for public
  - Goal was to provide clearer separation and remove duplicate calls to `authenticate` and `requireAdmin`
  - `authenticate()` is run for all calls to `/poll` at the top level => if the user has provided a token, the user data can be found from req.User
  - `requireAdmin()` is run for all calls to `/poll/admin`
    - User hasn't provided token => `401 Unauthorized`
    - User has provided token for non-admin user => `403 Forbidden`
    - User has provided token for admin => pass
- Fixed issue where vscode would not sometimes recognize the modified express Request/Response objects

I tested that the mentioned return values should work correctly 

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added thorough tests
