### PR TITLE
Allow logging in by pressing `Enter` key after typing username and password

### DIFF
--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,7 +1,7 @@
 import Field from './Field';
 import './LoginAndRegister.scss';
 import { login } from '../services/loginAndRegisterService';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Typography, Button, Link } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import BasicSnackbar from './BasicSnackbar';
@@ -38,6 +38,10 @@ function Login(props: any) {
     };
 
     const handleLogin = () => {
+        if (disableLogin) {
+            return;
+        }
+
         login(username, password)
             .then((response: any) => {
                 localStorage.setItem('token', response.token);
@@ -59,6 +63,23 @@ function Login(props: any) {
     const handleRegisterClick = () => {
         navigate('/register');
     };
+
+    const disableLogin = username.length === 0 || password.length < 6;
+
+    useEffect(() => {
+        const keyDownHandler = (event: any) => {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                handleLogin();
+            }
+        };
+
+        document.addEventListener('keydown', keyDownHandler);
+
+        return () => {
+            document.removeEventListener('keydown', keyDownHandler);
+        };
+    });
 
     return (
         <div className="main-wrapper">
@@ -85,6 +106,7 @@ function Login(props: any) {
                     className="login-btn"
                     sx={{ mt: '4.5rem', width: 200 }}
                     variant="outlined"
+                    disabled={disableLogin}
                     onClick={handleLogin}
                 >
                     Login

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -16,6 +16,7 @@ function Login(props: any) {
         message: '',
         severity: ''
     });
+    const disableLogin = username.length === 0 || password.length < 6;
 
     const InputHandler = (value: string, index: string) => {
         index === '0' ? setUsername(value) : setPassword(value);
@@ -38,6 +39,8 @@ function Login(props: any) {
     };
 
     const handleLogin = () => {
+        // This is here to prevent sending of unnecessary
+        // guaranteed to fail calls to the API
         if (disableLogin) {
             return;
         }
@@ -64,9 +67,8 @@ function Login(props: any) {
         navigate('/register');
     };
 
-    const disableLogin = username.length === 0 || password.length < 6;
-
     useEffect(() => {
+        // Listen for 'Enter'-key
         const keyDownHandler = (event: any) => {
             if (event.key === 'Enter') {
                 event.preventDefault();


### PR DESCRIPTION
### Fixes #169 

## Describe your changes

- Enter key does the same thing as the `Login`-button
- Disable the `Login`-button if no username is given and/or password is under the minimum length of 6
- Disable the login calls to API with the same logic

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added thorough tests
